### PR TITLE
feat: add loading of custom root certificates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ end
 ## Custom root certificates:
 
 To add custom root certificates, place them in the "garrysmod/tls_certificates" directory.
-The certificates must be X509 and in encoding in either pem or der. They must also end in the .pem or .der file extensions respective to their econding. If there si a problem loading the certificate, it'll be skipped over and a message will be displayed in the console.
+The certificates must be X509 and encoded in either pem or der. They must also end in the .pem or .der file extensions respective to their econding. If there is a problem loading the certificate, it'll be skipped over and a message will be displayed in the console.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ else
     my_http = HTTP
 end
 ```
+## Custom root certificates:
+
+To add custom root certificates, place them in the "garrysmod/tls_certificates" directory.
+The certificates must be X509 and in encoding in either pem or der. They must also end in the .pem or .der file extensions respective to their econding. If there si a problem loading the certificate, it'll be skipped over and a message will be displayed in the console.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod worker;
 use worker::WORKER_CHANNEL;
 
 mod channels;
+mod tls;
 
 unsafe extern "C-unwind" fn request(lua: lua::State) -> i32 {
 	use lua::LUA_TTABLE;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,62 @@
+use std::path::{Path, PathBuf};
+
+use reqwest::Certificate;
+
+const CUSTOM_ROOT_CERT_DIR: &'static str = "garrysmod/tls_certificates";
+
+#[derive(Debug)]
+pub enum CertificateError {
+	InvalidExtension(Option<String>),
+	Other(reqwest::Error),
+	IoError(std::io::Error),
+}
+impl From<reqwest::Error> for CertificateError {
+	fn from(err: reqwest::Error) -> Self {
+		CertificateError::Other(err)
+	}
+}
+impl From<std::io::Error> for CertificateError {
+	fn from(err: std::io::Error) -> Self {
+		CertificateError::IoError(err)
+	}
+}
+
+fn get_cert_from_file<P: AsRef<Path>>(path: P) -> Result<Certificate, CertificateError> {
+	let path = path.as_ref();
+
+	let ext = match path.extension().and_then(|ext| ext.to_str()) {
+		Some(ext @ ("pem" | "der")) => ext,
+		_ => {
+			return Err(CertificateError::InvalidExtension(
+				path.extension().map(|ext| ext.to_string_lossy().into_owned()),
+			))
+		}
+	};
+
+	let cert = std::fs::read(path)?;
+
+	Ok(match ext {
+		"pem" => Certificate::from_pem(&cert)?,
+		"der" => Certificate::from_der(&cert)?,
+		_ => unreachable!(),
+	})
+}
+
+pub fn get_loadable_certificates() -> Result<Vec<Certificate>, std::io::Error> {
+	if !PathBuf::from(CUSTOM_ROOT_CERT_DIR).exists() {
+		return Ok(vec![]);
+	}
+
+	Ok(
+		std::fs::read_dir(CUSTOM_ROOT_CERT_DIR)?
+			.filter_map(|entry| entry.ok())
+			.filter_map(|entry| match get_cert_from_file(entry.path()) {
+				Ok(cert) => Some(cert),
+				Err(err) => {
+					eprintln!("[gmsv_reqwest] Error loading certificate \"{:?}\": {:#?}", entry.path().file_name(), err);
+					None
+				}
+			})
+			.collect::<Vec<Certificate>>()
+	)
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,10 +1,10 @@
-use std::fs::{read, DirEntry};
-use reqwest::{Certificate, Client, ClientBuilder, header::HeaderMap};
+use reqwest::{Client, ClientBuilder, header::HeaderMap};
 
 use crate::{
 	channels::{StaticReceiver, StaticSender},
 	http::HTTPRequest,
 	lua::{self, LuaInt, LuaReference, LUA_REGISTRYINDEX},
+	tls
 };
 
 pub enum CallbackResult {
@@ -13,18 +13,18 @@ pub enum CallbackResult {
 	FreeReference(LuaReference),
 }
 
-
-fn create_client() -> Client{
-	let certs = get_loadable_certificates();
-
+fn create_client() -> Client {
 	let mut client_builder = ClientBuilder::new();
-	for cert in certs{
-		client_builder = client_builder.add_root_certificate(cert);
+
+	match tls::get_loadable_certificates() {
+		Ok(certs) => for cert in certs {
+			client_builder = client_builder.add_root_certificate(cert);
+		},
+		Err(err) => eprintln!("[gmsv_reqwest] Unable to load TLS Certificates: {}", err)
 	}
 
-	return client_builder.build().unwrap();
+	client_builder.build().expect("Failed to initialize reqwest client")
 }
-
 
 lazy_static! {
 	pub static ref WORKER_CHANNEL: StaticSender<HTTPRequest> = StaticSender::uninit();
@@ -32,73 +32,7 @@ lazy_static! {
 	static ref CLIENT: reqwest::Client = create_client();
 }
 
-static CUSTOM_ROOT_CERT_DIR: &str = "./garrysmod/tls_certificates/";
-
-fn get_cert_from_file(path_ref: DirEntry) -> Result<Certificate, String>{
-	let path = path_ref.path();
-
-	let ext_opt = path.extension();
-	if ext_opt.is_some(){
-		let extension = ext_opt.unwrap();
-		let file = read(&path);
-
-		if file.is_err() {
-			return Err(format!("[Reqwest] Unable to open file: {}", path.display()));
-		}
-		
-		let file_data: &[u8] = &file.unwrap()[..];
-		
-		let data: Result<Certificate, reqwest::Error>;
-
-		match extension.to_str().unwrap() {
-			"pem" => {
-				data = Certificate::from_pem(file_data);
-			},
-			"der" => {
-				data = Certificate::from_der(file_data);
-			},
-			_ =>{
-				return Err(format!("[Reqwest] file extension incorrect for: {:?}", path.display()));
-			}
-		}
-
-		match data {
-			Ok(cert) => {
-				println!("[Reqwest] Loaded Certificate: {:?}", path.display());
-				return Ok(cert);
-			}
-			Err(error) =>{
-				return Err(format!("[Reqwest] got error while parsing certificate: {:?} Error: {:?}", path.display(), error.to_string()))
-			}
-		}
-	}else{
-		return Err(format!("[Reqwest] No file extension for certificate: {:?}", path.display()));
-	}
-}
-
-fn get_loadable_certificates() -> Vec<Certificate> {
-	// thank you billy for improving this :)
-    std::fs::read_dir(CUSTOM_ROOT_CERT_DIR)
-    .map(|dir| {
-        dir.filter_map(|entry| entry.ok()).filter_map(|entry| {
-            match get_cert_from_file(entry) {
-                Ok(cert) => Some(cert),
-                Err(err) => {
-                    eprintln!("{}", err);
-                    None
-                }
-            }
-        }).collect::<Vec<Certificate>>()
-    })
-    .map_err(|err| {
-        println!("[Reqwest] Unable to load TLS Certificates: {}", err);
-        err
-    })
-    .unwrap_or_default()
-}
-
 pub fn request_worker() {
-
 	let (tx, request_rx) = crossbeam::channel::unbounded::<HTTPRequest>();
 	WORKER_CHANNEL.borrow_mut().replace(tx);
 


### PR DESCRIPTION
This pull request allows for the addition of custom root certificates, by adding them into the: garrysmod/tls_certificates directory.
As per the readme:

To add custom root certificates, place them in the "garrysmod/tls_certificates" directory.
The certificates must be X509 and encoded in either pem or der. They must also end in the .pem or .der file extensions respective to their econding. If there is a problem loading the certificate, it'll be skipped over and a message will be displayed in the console.
